### PR TITLE
Add tree-sitter-bicep grammar version to -source-alist

### DIFF
--- a/bicep-ts-mode.el
+++ b/bicep-ts-mode.el
@@ -160,7 +160,8 @@ Return nil if there is no name or if NODE is not a defun node."
   "Major mode for editing BICEP, powered by tree-sitter."
   :group 'bicep-mode
 
-  (when (treesit-ready-p 'bicep)
+  (if (not (treesit-ready-p 'bicep))
+      (message "Please run `M-x treesit-install-language-grammar RET bicep'")
     (treesit-parser-create 'bicep)
 
     ;; Comments

--- a/bicep-ts-mode.el
+++ b/bicep-ts-mode.el
@@ -197,6 +197,10 @@ Return nil if there is no name or if NODE is not a defun node."
 
     (treesit-major-mode-setup)))
 
+;; Our treesit-font-lock-rules expect this version of the grammar:
+(add-to-list 'treesit-language-source-alist
+             '(bicep . ("https://github.com/tree-sitter-grammars/tree-sitter-bicep" "v1.1.0")))
+
 ;;;###autoload
 (and (fboundp 'treesit-ready-p)
      (treesit-ready-p 'bicep)


### PR DESCRIPTION
Should it also ```(unless (treesit-ready-p 'bicep) (message "Please run `M-x treesit-install-language-grammar RET bicep'"))``` ?