### PR TITLE
Fix autoload for bicep--register-langserver

### DIFF
--- a/bicep-ts-mode.el
+++ b/bicep-ts-mode.el
@@ -237,6 +237,7 @@ Changes may require an Emacs-restart to take effect."
   (bicep--download-langserver)
   (bicep--register-langserver))
 
+;;;###autoload
 (defun bicep--register-langserver ()
   (defvar eglot-server-programs)
   (and (file-exists-p (bicep-langserver-path))


### PR DESCRIPTION
* bicep-ts-mode.el (bicep--register-langserver): Add an autoload in case of loading eglot before loading bicep-ts-mode.

When using lazy-loading of the package (eval-after-load), eglot might sometimes be loaded before this mode.  Particularly on packages where eglot might be a dependency.

I already did the FSF paperwork.