### PR TITLE
Improved completion for resource type names

### DIFF
--- a/bicep-ts-mode.el
+++ b/bicep-ts-mode.el
@@ -32,6 +32,7 @@
 (require 'treesit)
 (require 'json)
 (require 'url)
+(require 'thingatpt)
 
 (declare-function treesit-parser-create "treesit.c")
 (declare-function treesit-induce-sparse-tree "treesit.c")

--- a/bicep-ts-mode.el
+++ b/bicep-ts-mode.el
@@ -259,6 +259,13 @@ Return nil if there is no name or if NODE is not a defun node."
        (treesit-node-child defun-node 1)
        t))))
 
+(defun bicep-ts-mode--resource-type-symbol-bounds ()
+  (let ((node (treesit-node-at (point))))
+    (when (string-equal (treesit-node-type node) "string_content")
+      (let ((from (treesit-node-start node))
+	    (len (string-match "[ \n\t@]" (treesit-node-text node))))
+	(cons from (if len (+ from len) (treesit-node-end node)))))))
+
 ;; required due to named-let.
 (eval-when-compile (require 'subr-x))
 (defun bicep-ts-mode--find-declaration-node (node)
@@ -317,6 +324,11 @@ Return the first matching node, or nil if none is found."
                   ("Resources" "\\`resource_declaration\\'" nil nil)
                   ("Outputs" "\\`output_declaration\\'" nil nil)))
 
+    ;; thing-at-point
+    (setq-local bounds-of-thing-at-point-provider-alist
+		(cons '(symbol . bicep-ts-mode--resource-type-symbol-bounds)
+		      bounds-of-thing-at-point-provider-alist))
+    
     (treesit-major-mode-setup)))
 
 ;; quote management


### PR DESCRIPTION
This patch adds a `bounds-of-thing-at-point` handler that (in my setup with corfu autocomplete at least) significantly improves filtering of completion candidates for resource type names by allowing eglot to filter on the entire type name instead of just the last element. TBH, completion of resource types still isn't great, but I think any further improvements would have to be on the language server side.

I have been using this for a few weeks now in a project in active development and so far as I can tell it doesn't break anything else, but it is a bit of a kludge: there's no easy or efficient way, given the way the treesitter grammar works, to tell if we are actually looking at a resource class name, so it looks for strings instead. It will probably break if/when finer-grained completion of resource types is implemented in the langserver.

